### PR TITLE
Доступная разметка внутренней страницы

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -304,6 +304,10 @@ input[type="radio"].visually-hidden {
   color: var(--basic-red);
 }
 
+.header-phone:focus {
+  border: 3px solid var(--intense-dadrkblue);
+}
+
 .header-phone-container address {
   margin-top: 2px;
   margin-left: 12px;

--- a/css/style.css
+++ b/css/style.css
@@ -1675,6 +1675,9 @@ input[type="radio"].visually-hidden {
 }
 
 .catalog-item-oldprice {
+  max-width: 160px;
+
+  text-align: center;
   text-decoration: line-through;
 
   color: var(--oldprice-color);
@@ -1723,8 +1726,6 @@ input[type="radio"].visually-hidden {
   display: flex;
   width: 38px;
   min-height: 38px;
-  /* margin-right: 6px; */
-  /* padding: 10px 15px; */
   align-items: center;
   justify-content: center;
   border: 1px solid var(--pagination-border-color);
@@ -2575,6 +2576,10 @@ input[type="radio"].visually-hidden {
   margin-top: 26px;
   margin-right: 19px;
   flex-shrink: 0;
+}
+
+.popular-manufacturer-item a {
+  transition: filter 0.3s ease-in-out;
 }
 
 .popular-manufacturer-item a:hover,

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         <nav class="main-navigation">
           <ul class="main-navigation-list">
             <li class="main-navigation-item">
-              <a>Главная</a>
+              <a href="#">Главная</a>
             </li>
             <li class="main-navigation-item">
               <a href="#">Компания</a>
@@ -190,44 +190,53 @@
             <a href="#">все производители</a>
           </div>
           <ul class="popular-manufacturer-list">
+            <h3 class="visually-hidden">Список производителей</h3>
             <li class="popular-manufacturer-item">
               <a href="#">
                 <img src="img/bosh-logo.png" width="220" height="145" alt="Bosch.">
+                <span class="visually-hidden">Перейти к товарам от производителя</span>
               </a>
             </li>
             <li class="popular-manufacturer-item">
               <a href="#">
                 <img src="img/makita-logo.png" width="220" height="145" alt="Makita.">
+                <span class="visually-hidden">Перейти к товарам от производителя</span>
               </a>
             </li>
             <li class="popular-manufacturer-item">
               <a href="#">
                 <img src="img/dewalt-logo.png" width="220" height="145" alt="DeWalt.">
+                <span class="visually-hidden">Перейти к товарам от производителя</span>
               </a>
             </li>
             <li class="popular-manufacturer-item">
               <a href="#">
                 <img src="img/interscol-logo.png" width="220" height="145" alt="Интерскол.">
+                <span class="visually-hidden">Перейти к товарам от производителя</span>
               </a>
             </li>
             <li class="popular-manufacturer-item">
               <a href="#">
                 <img src="img/hitachi-logo.png" width="220" height="145" alt="Hitachi.">
+                <span class="visually-hidden">Перейти к товарам от производителя</span>
               </a>
             </li>
             <li class="popular-manufacturer-item">
               <a href="#">
                 <img src="img/lg-logo.png" width="220" height="145" alt="LG.">
+                <span class="visually-hidden">Перейти к товарам от производителя</span>
               </a>
             </li>
             <li class="popular-manufacturer-item">
               <a href="#">
                 <img src="img/aeg-logo.png" width="220" height="145" alt="AEG.">
+                <span class="visually-hidden">Перейти к товарам от производителя</span>
               </a>
             </li>
             <li class="popular-manufacturer-item">
               <a href="#">
                 <img src="img/metabo-logo.png" width="220" height="145" alt="Metabo.">
+                <span class="visually-hidden">Перейти к товарам от производителя</span>
               </a>
             </li>
           </ul>

--- a/inner.html
+++ b/inner.html
@@ -302,19 +302,27 @@
         </div>
 
         <div class="catalog-controls">
-          <h2 class="visually-hidden">Навигация по каталогу</h2>
+          <h2 class="visually-hidden">Пагинация каталога</h2>
           <ul class="catalog-controls-list">
             <li class="catalog-controls-item">
-              <span class="visually-hidden">Страница</span>
-              <a class="current-page" href="#">1</a>
+              <a class="current-page" href="#">
+                1
+                <span class="visually-hidden">Страница</span>
+              </a>
             </li>
             <li class="catalog-controls-item">
+              <a href="#">
+                2
               <span class="visually-hidden">Страница</span>
-              <a href="#">2</a>
+
+              </a>
             </li>
             <li class="catalog-controls-item">
+              <a href="#">
+                3
               <span class="visually-hidden">Страница</span>
-              <a href="#">3</a>
+
+              </a>
             </li>
             <li class="catalog-controls-item">
               <button type="button">

--- a/inner.html
+++ b/inner.html
@@ -302,18 +302,25 @@
         </div>
 
         <div class="catalog-controls">
+          <h2 class="visually-hidden">Навигация по каталогу</h2>
           <ul class="catalog-controls-list">
             <li class="catalog-controls-item">
+              <span class="visually-hidden">Страница</span>
               <a class="current-page" href="#">1</a>
             </li>
             <li class="catalog-controls-item">
+              <span class="visually-hidden">Страница</span>
               <a href="#">2</a>
             </li>
             <li class="catalog-controls-item">
+              <span class="visually-hidden">Страница</span>
               <a href="#">3</a>
             </li>
             <li class="catalog-controls-item">
-              <button type="button">Следующая</button>
+              <button type="button">
+                Следующая
+                <span class="visually-hidden">Страница</span>
+              </button>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
В пагинацию добавлен скрытый заголовок и спан с visualli-hidden для
более понятного обозначения страниц каталога при чтении скринридером

---
:mortar_board: [Доступная разметка главной страницы](https://up.htmlacademy.ru/htmlcss/29/user/1353125/tasks/15)

---
:mortar_board: [Доступная разметка внутренней страницы](https://up.htmlacademy.ru/htmlcss/29/user/1353125/tasks/16)

:boom: https://htmlacademy-htmlcss.github.io/1353125-technomart-29/10/